### PR TITLE
Saving imageurls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ end
 group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
+  gem 'rails-controller-testing'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,8 @@ end
 
 group :test do
   gem 'capybara'
-  gem 'selenium-webdriver'
   gem 'rails-controller-testing'
+  gem 'selenium-webdriver'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.0)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -231,6 +235,7 @@ DEPENDENCIES
   pronto-rubocop
   puma (~> 3.0)
   rails (~> 5.2.0)
+  rails-controller-testing
   sass-rails (~> 5.0, >= 5.0.6)
   selenium-webdriver
   spring
@@ -245,4 +250,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/app/controllers/imageurls_controller.rb
+++ b/app/controllers/imageurls_controller.rb
@@ -1,0 +1,22 @@
+class ImageurlsController < ApplicationController
+  def show
+    begin
+      @imageurl = Imageurl.find(params[:id])
+    rescue
+      head 404
+    end
+  end
+
+  def new; end
+
+  def create
+    @imageurl = Imageurl.new(params.require(:imageurl).permit(:url))
+    if @imageurl.valid? && @imageurl.save
+      flash[:success] = 'Image URL added successfully!'
+      redirect_to @imageurl
+    else
+      flash[:error] = @imageurl.errors.full_messages.join(' ')
+      render 'new', status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/imageurls_controller.rb
+++ b/app/controllers/imageurls_controller.rb
@@ -13,7 +13,7 @@ class ImageurlsController < ApplicationController
       flash[:success] = 'Image URL added successfully!'
       redirect_to @imageurl
     else
-      flash[:error] = @imageurl.errors.full_messages.join(' ')
+      flash[:warning] = @imageurl.errors.full_messages.join(' ')
       render 'new', status: :unprocessable_entity
     end
   end

--- a/app/controllers/imageurls_controller.rb
+++ b/app/controllers/imageurls_controller.rb
@@ -13,7 +13,7 @@ class ImageurlsController < ApplicationController
       flash[:success] = 'Image URL added successfully!'
       redirect_to @imageurl
     else
-      flash[:warning] = @imageurl.errors.full_messages.join(' ')
+      flash[:danger] = @imageurl.errors.full_messages.join(' ')
       render 'new', status: :unprocessable_entity
     end
   end

--- a/app/controllers/imageurls_controller.rb
+++ b/app/controllers/imageurls_controller.rb
@@ -1,10 +1,8 @@
 class ImageurlsController < ApplicationController
   def show
-    begin
-      @imageurl = Imageurl.find(params[:id])
-    rescue
-      head 404
-    end
+    @imageurl = Imageurl.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    head 404
   end
 
   def new; end

--- a/app/helpers/imageurls_helper.rb
+++ b/app/helpers/imageurls_helper.rb
@@ -1,0 +1,2 @@
+module ImageurlsHelper
+end

--- a/app/models/imageurl.rb
+++ b/app/models/imageurl.rb
@@ -1,0 +1,5 @@
+class Imageurl < ApplicationRecord
+  validates :url, presence: true, null: false,
+                  format: { with: %r{\Ahttps?://},
+                            message: 'must begin with http:// or https://' }
+end

--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -1,3 +1,4 @@
     Hello, World!
 
-    We're trying to display SOMETHING.
+    You can add image URLs here:
+    <%= link_to 'New image URL', new_imageurl_path %>

--- a/app/views/imageurls/new.html.erb
+++ b/app/views/imageurls/new.html.erb
@@ -1,5 +1,7 @@
 <h1>New Image URL</h1>
 
+<!-- FIXME fix styling of flash message -->
+
 <%= form_with scope: :imageurl, url: imageurls_path, local: true do |form| %>
     <p>
       <%= form.label :url %>

--- a/app/views/imageurls/new.html.erb
+++ b/app/views/imageurls/new.html.erb
@@ -1,0 +1,12 @@
+<h1>New Image URL</h1>
+
+<%= form_with scope: :imageurl, url: imageurls_path, local: true do |form| %>
+    <p>
+      <%= form.label :url %>
+      <%= form.text_field :url %>
+    </p>
+
+    <p>
+      <%= form.submit %>
+    </p>
+<% end %>

--- a/app/views/imageurls/new.html.erb
+++ b/app/views/imageurls/new.html.erb
@@ -1,7 +1,5 @@
 <h1>New Image URL</h1>
 
-<!-- FIXME fix styling of flash message -->
-
 <%= form_with scope: :imageurl, url: imageurls_path, local: true do |form| %>
     <p>
       <%= form.label :url %>

--- a/app/views/imageurls/show.html.erb
+++ b/app/views/imageurls/show.html.erb
@@ -1,0 +1,9 @@
+<p>
+  <strong>Image URL:</strong>
+  <%= @imageurl.url %>
+</p>
+
+<p>
+  <strong>Image:</strong>
+  <img src="<%= @imageurl.url %>" />
+</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,13 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
   </head>
   <body>
+
+    <div class="flashmessagecontainer">
+    <% flash.each do |key, value| %>
+        <div class="alert alert-<%= key %>"><%= value %></div>
+    <% end %>
+    </div>
+
     <%= yield %>
 
     <!-- Optional JavaScript -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
+
+  resources :imageurls
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
 
+  # FIXME trim down routes
   resources :imageurls
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
 
-  # FIXME trim down routes
-  resources :imageurls
+  resources :imageurls, only: %i[new create show]
 end

--- a/db/migrate/20190403082628_create_imageurls.rb
+++ b/db/migrate/20190403082628_create_imageurls.rb
@@ -1,0 +1,9 @@
+class CreateImageurls < ActiveRecord::Migration[5.2]
+  def change
+    create_table :imageurls do |t|
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190403082628_create_imageurls.rb
+++ b/db/migrate/20190403082628_create_imageurls.rb
@@ -1,3 +1,4 @@
+# FIXME non-null
 class CreateImageurls < ActiveRecord::Migration[5.2]
   def change
     create_table :imageurls do |t|

--- a/db/migrate/20190403082628_create_imageurls.rb
+++ b/db/migrate/20190403082628_create_imageurls.rb
@@ -1,4 +1,3 @@
-# FIXME non-null
 class CreateImageurls < ActiveRecord::Migration[5.2]
   def change
     create_table :imageurls do |t|

--- a/db/migrate/20190404080300_make_url_non_null.rb
+++ b/db/migrate/20190404080300_make_url_non_null.rb
@@ -1,0 +1,5 @@
+class MakeUrlNonNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column(:imageurls, :url, :string, null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_04_03_082628) do
+
+  create_table "imageurls", force: :cascade do |t|
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_03_082628) do
+ActiveRecord::Schema.define(version: 2019_04_04_080300) do
 
   create_table "imageurls", force: :cascade do |t|
-    t.string "url"
+    t.string "url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -17,7 +17,8 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'showing invalid id fails' do
-    get format('/imageurls/%<id>i', id: [Imageurl.last.id + 1])
+    post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
+    get format('/imageurls/%<id>i', id: Imageurl.last.id + 1)
     assert_response :not_found
   end
 

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -9,15 +9,18 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'creating a new URL works' do
-    # FIXME split up this test
     # FIXME check correct flash message is shown
     assert_difference('Imageurl.count') do
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
       assert_redirected_to Imageurl.last
-      # check new record can be shown
-      get imageurl_path(Imageurl.first)
-      assert_response :success
     end
+  end
+
+  test 'showing valid id succeeds' do
+    url = Imageurl.new(url: 'http://host.com/image.jpg')
+    assert url.save
+    get imageurl_url(url)
+    assert_response :success
   end
 
   test 'showing invalid id fails' do

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -8,10 +8,10 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'creating a new URL works' do
-    # FIXME check correct flash message is shown
     assert_difference('Imageurl.count') do
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
       assert_redirected_to Imageurl.last
+      assert_equal flash[:success], 'Image URL added successfully!'
       assert_template nil
     end
   end
@@ -33,8 +33,8 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
 
   test 'creating an invalid URL fails' do
     post '/imageurls', params: { imageurl: { url: 'foobar' } }
-    # FIXME check correct flash message is shown
     assert_response :unprocessable_entity
+    assert_equal flash[:warning], 'Url must begin with http:// or https://'
     assert_template 'new'
   end
 end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -33,7 +33,7 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   test 'creating an invalid URL fails' do
     post '/imageurls', params: { imageurl: { url: 'foobar' } }
     assert_response :unprocessable_entity
-    assert_equal 'Url must begin with http:// or https://', flash[:warning]
+    assert_equal 'Url must begin with http:// or https://', flash[:danger]
     assert_template 'new'
   end
 end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+# FIXME check correct view is rendered in each case
+
 class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   test 'should respond to /imageurls/new' do
     get '/imageurls/new'
@@ -7,6 +9,8 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'creating a new URL works' do
+    # FIXME split up this test
+    # FIXME check correct flash message is shown
     assert_difference('Imageurl.count') do
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
       assert_redirected_to Imageurl.last
@@ -24,6 +28,7 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
 
   test 'creating an invalid URL fails' do
     post '/imageurls', params: { imageurl: { url: 'foobar' } }
+    # FIXME check correct flash message is shown
     assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
-# FIXME check correct view is rendered in each case
-
 class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   test 'should respond to /imageurls/new' do
     get '/imageurls/new'
     assert_response :success
+    assert_template 'new'
   end
 
   test 'creating a new URL works' do
@@ -13,6 +12,7 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Imageurl.count') do
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
       assert_redirected_to Imageurl.last
+      assert_template nil
     end
   end
 
@@ -21,17 +21,20 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
     assert url.save
     get imageurl_url(url)
     assert_response :success
+    assert_template 'show'
   end
 
   test 'showing invalid id fails' do
     post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
     get format('/imageurls/%<id>i', id: Imageurl.last.id + 1)
     assert_response :not_found
+    assert_template nil
   end
 
   test 'creating an invalid URL fails' do
     post '/imageurls', params: { imageurl: { url: 'foobar' } }
     # FIXME check correct flash message is shown
     assert_response :unprocessable_entity
+    assert_template 'new'
   end
 end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -8,7 +8,7 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
 
   test 'creating a new URL works' do
     assert_difference('Imageurl.count') do
-      post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' }}
+      post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
       assert_redirected_to Imageurl.last
       # check new record can be shown
       get imageurl_path(Imageurl.first)
@@ -17,12 +17,12 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'showing invalid id fails' do
-    get '/imageurls/%i' % [Imageurl.last.id + 1]
+    get format('/imageurls/%<id>i', id: [Imageurl.last.id + 1])
     assert_response :not_found
   end
 
   test 'creating an invalid URL fails' do
-    post '/imageurls', params: { imageurl: { url: 'foobar' }}
+    post '/imageurls', params: { imageurl: { url: 'foobar' } }
     assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class ImageurlsControllerTest < ActionDispatch::IntegrationTest
+  test 'should respond to /imageurls/new' do
+    get '/imageurls/new'
+    assert_response :success
+  end
+
+  test 'creating a new URL works' do
+    assert_difference('Imageurl.count') do
+      post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' }}
+      assert_redirected_to Imageurl.last
+      # check new record can be shown
+      get imageurl_path(Imageurl.first)
+      assert_response :success
+    end
+  end
+
+  test 'showing invalid id fails' do
+    get '/imageurls/%i' % [Imageurl.last.id + 1]
+    assert_response :not_found
+  end
+
+  test 'creating an invalid URL fails' do
+    post '/imageurls', params: { imageurl: { url: 'foobar' }}
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -10,10 +10,10 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   test 'creating a new URL works' do
     assert_difference('Imageurl.count') do
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
-      assert_redirected_to Imageurl.last
-      assert_equal flash[:success], 'Image URL added successfully!'
-      assert_template nil
     end
+    assert_redirected_to Imageurl.last
+    assert_equal flash[:success], 'Image URL added successfully!'
+    assert_template nil
   end
 
   test 'showing valid id succeeds' do

--- a/test/controllers/imageurls_controller_test.rb
+++ b/test/controllers/imageurls_controller_test.rb
@@ -12,13 +12,12 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
       post '/imageurls', params: { imageurl: { url: 'http://host.com/image.jpg' } }
     end
     assert_redirected_to Imageurl.last
-    assert_equal flash[:success], 'Image URL added successfully!'
+    assert_equal 'Image URL added successfully!', flash[:success]
     assert_template nil
   end
 
   test 'showing valid id succeeds' do
-    url = Imageurl.new(url: 'http://host.com/image.jpg')
-    assert url.save
+    url = Imageurl.create!(url: 'http://host.com/image.jpg')
     get imageurl_url(url)
     assert_response :success
     assert_template 'show'
@@ -34,7 +33,7 @@ class ImageurlsControllerTest < ActionDispatch::IntegrationTest
   test 'creating an invalid URL fails' do
     post '/imageurls', params: { imageurl: { url: 'foobar' } }
     assert_response :unprocessable_entity
-    assert_equal flash[:warning], 'Url must begin with http:// or https://'
+    assert_equal 'Url must begin with http:// or https://', flash[:warning]
     assert_template 'new'
   end
 end

--- a/test/models/imageurl_test.rb
+++ b/test/models/imageurl_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class ImageurlTest < ActiveSupport::TestCase
+  test 'image URL beginning with http is valid' do
+    url = Imageurl.new(url: 'http://host.com/aloha.png')
+    assert url.valid?
+  end
+
+  test 'image URL beginning with https is valid' do
+    url = Imageurl.new(url: 'https://host.com/aloha.png')
+    assert url.valid?
+  end
+
+  test 'image URL with other url is invalid' do
+    url = Imageurl.new(url: 'foobar')
+    assert_not url.valid?
+    assert_includes url.errors[:url], 'must begin with http:// or https://'
+  end
+
+  test 'image URL without url is invalid' do
+    url = Imageurl.new
+    assert_not url.valid?
+    assert_includes url.errors[:url], 'can\'t be blank'
+    url = Imageurl.new(url: nil)
+    assert_not url.valid?
+    assert_includes url.errors[:url], 'can\'t be blank'
+  end
+end


### PR DESCRIPTION
Closes #2 

Image URLs can be added to the database. Landing page has a link to the submission form.

Validation is basic:  A image URL must begin with http:// or https://.

Index action is deferred to #3.
